### PR TITLE
[doc] buildopts - fix punctuation in LargeFile URL

### DIFF
--- a/CMake/buildopts.html
+++ b/CMake/buildopts.html
@@ -975,7 +975,7 @@ dt.skiplogo::before         {
     </p>
     <p>
         See the 
-        <a href="http://www.unix.org/version2/whatsnew/lfs.html." target="_blank">
+        <a href="http://www.unix.org/version2/whatsnew/lfs.html" target="_blank">
                 document created by the Large File Summit</a> 
         for details about how non-native large file support came to be a part of
         The Single UNIX Specification Version 2, in 1996.


### PR DESCRIPTION
The current link is 404 due to extra punctuation. Removing the trailing `.` allows the page to load

```
$ curl -vkIL 'https://www.unix.org/version2/whatsnew/lfs.html.'
< HTTP/1.1 404 Not Found
$ curl -vkIL 'https://www.unix.org/version2/whatsnew/lfs.html.'
< HTTP/1.1 200 OK
```